### PR TITLE
Fixed two small bugs.

### DIFF
--- a/Brickficiency/Main.cs
+++ b/Brickficiency/Main.cs
@@ -1139,6 +1139,7 @@ namespace Brickficiency
                 string pageSource;
                 //            StreamWriter swr = new StreamWriter(debugwebreqfilename);
 
+                // "(DateTime.Now > cookietime.AddMinutes(10))" is probably not an appropriate check as to wether to log in again.
                 if ((login == true) && ((loggedin == false) || (cookietime == null) || (DateTime.Now > cookietime.AddMinutes(10))))
                 {
                     var credential = _bricklinkCredentialProvider.GetCredentials();
@@ -1791,10 +1792,11 @@ namespace Brickficiency
                 }
                 else if (dgv[currenttab].Columns[e.ColumnIndex].Name == "name")
                 {
+                    // The changeItemWindow Form must be 'Loaded' before 'DisplayItem(...)' is called.
+                    changeItemWindow.Show();    // 'Show()' is used to invoke 'Load()'
                     changeItemWindow.DisplayItem(dgv[currenttab].Rows[e.RowIndex]);
                     changeItemWindow.BringToFront();
                     changeItemWindow.WindowState = FormWindowState.Normal;
-                    changeItemWindow.Show();
                 }
                 else if (dgv[currenttab].Columns[e.ColumnIndex].Name == "condition")
                 {
@@ -2096,7 +2098,10 @@ namespace Brickficiency
         #region datagridview dataerror
         private void dgvDataError(object sender, DataGridViewDataErrorEventArgs anError)
         {
-            AddStatus("Invalid value: " + dgv[currenttab].EditingControl.Text + Environment.NewLine);
+            if (dgv[currenttab].EditingControl != null)
+                AddStatus("Invalid value: " + dgv[currenttab].EditingControl.Text + Environment.NewLine);
+            else
+                AddStatus("Invalid value: No EdditControl" + Environment.NewLine);
         }
         #endregion
 

--- a/WindmillHelix.Brickficiency2.ExternalApi/Bricklink/BricklinkLoginApi.cs
+++ b/WindmillHelix.Brickficiency2.ExternalApi/Bricklink/BricklinkLoginApi.cs
@@ -48,7 +48,8 @@ namespace WindmillHelix.Brickficiency2.ExternalApi.Bricklink
                 var serializer = new JsonSerializer();
 
                 dynamic content = serializer.Deserialize(reader);
-                var result = content.returnCode.ToString() == "0";
+                var result =    content.returnCode.ToString() == "0"
+                             || content.returnMessage.ToString() == "Already Logged-in!";
 
                 return result;
             }


### PR DESCRIPTION
The first is a bit of a hack which reports a login as successful if the user was still logged-in.  It would probably be better to check if already logged in rather than rely on the "already logged-in" error message.

The other prevents the "Change Item" window appearing blank the first time it appears.
